### PR TITLE
Generalize terminology

### DIFF
--- a/bin/rallymanager
+++ b/bin/rallymanager
@@ -31,6 +31,7 @@ def create_rally(args):
 
     config = json.load(open(args.config))
     manager.create_rally(rally_number=args.rally_number,
+                         rally_title=args.title,
                          config=config)
 
 def get_rallies(args):

--- a/kirallymanager/manager.py
+++ b/kirallymanager/manager.py
@@ -262,7 +262,7 @@ def create_rally(rally_number, rally_title=None,
     rally_team_name = "ki Rally %s" % (rally_number, )
 
     rally_admin_team_id = config['rally_admin_team_id']
-    rally_table_id = config['rallyTableId']
+    rally_table_id = config['rally_table_id']
     team_permissions = {rally_admin_team_id: config['rallyAdminTeamPermissions']} # pylint: disable=line-too-long
 
     # Create a rally team.

--- a/kirallymanager/manager.py
+++ b/kirallymanager/manager.py
@@ -421,7 +421,7 @@ def create_sprint(rally_number, sprint_letter, sprint_title=None,
                            consortium=consortium,
                            rallyTeam=rally_team.id)
 
-        sprint_project = synapseclient.Project(name=sprint_name,
+        sprint_project = synapseclient.Project(name=sprint_title,
                                                annotations=annotations)
 
 

--- a/kirallymanager/manager.py
+++ b/kirallymanager/manager.py
@@ -379,9 +379,7 @@ def create_sprint(rally_number, sprint_letter, sprint_title=None,
     # Sprint Configuration
     sprint_number = "%s%s" % (rally_number, sprint_letter)
     if not sprint_title:
-        sprint_title = "Sprint %s" % (sprint_number, )
-
-    sprint_name = "ki %s" % (sprint_title, )
+        sprint_title = "ki Sprint %s" % (sprint_number, )
 
     consortium = config.get('consortium', None)
 

--- a/kirallymanager/manager.py
+++ b/kirallymanager/manager.py
@@ -392,8 +392,11 @@ def create_sprint(rally_number, sprint_letter, sprint_title=None,
     # all files table in the Ki rally working group project
     all_files_working_group_schema = syn.get(config['allFilesSchemaId'])
 
-    rally_project = create_rally(rally_number=rally_number, config=config)
+    rally_project = get_rally(config['root_project_id'],
+                              rally_number=rally_number)
 
+    if rally_project is None:
+        raise ValueError(f"No rally {rally_number}. Please create it first.")
     # Get the rally team.
     rally_team = syn.getTeam(rally_project.annotations.get('rallyTeam', None)[0]) # pylint: disable=line-too-long
 


### PR DESCRIPTION
First pass to generalize terminology away from rally/sprint.

Still has some things via function and variable names - this will need to change the annotations set on tables, and then will need to use alias in the table queries to still show with rally/sprint terminology.